### PR TITLE
Fix for ReadMetadata and SOQL query character limit

### DIFF
--- a/lib/sfdc_apis/dependencies.js
+++ b/lib/sfdc_apis/dependencies.js
@@ -551,7 +551,14 @@ function dependencyApi(connection,entryPoint,cache){
 
         if(uncachedFields.length){
             let mdapi = metadataAPI(connection,logError);
-            records = await mdapi.readMetadata('CustomField',uncachedFields);
+            /**
+             * Read Metadata has a limit of only 10 items per request. So, we make calls in chunks of 10
+             * https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_readMetadata.htm
+             */
+            let j = 0;
+            while (j < uncachedFields.length) {
+              records.push(await mdapi.readMetadata("CustomField", uncachedFields.slice(j, (j += 10))));
+            }            
             cache.cacheFieldNames(uncachedFields);
         }
 

--- a/lib/sfdc_apis/dependencies.js
+++ b/lib/sfdc_apis/dependencies.js
@@ -786,13 +786,18 @@ function dependencyApi(connection,entryPoint,cache){
      * of customFieldId to customObjectId
      */
     async function getFieldToEntityMap(customFieldIds){
+      
+        let records = [];
+        let i = 0;
+        // query in chunks as soql query has 20,000 character limit.
+        while (i < customFieldIds.length) {
+          let soqlQuery = createCustomFieldQuery(customFieldIds.slice(i, (i += 500)));
+          records.push(...(await restApi.query(soqlQuery))?.records);
+        }      
     
-        let soqlQuery = createCustomFieldQuery(customFieldIds);
-        
-        let results = await restApi.query(soqlQuery);
         let customFieldIdToEntityId = new Map();
     
-        results.records.forEach(rec => {
+        records.forEach(rec => {
             customFieldIdToEntityId.set(rec.Id,rec.TableEnumOrId);
         });
     


### PR DESCRIPTION
- [x] - Fix for ReadMetadata which has a limit of 10 items per request. https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_readMetadata.htm
- [x] - Fix for soql query character limit of 20,000. 